### PR TITLE
Fix support to private properties in Entity classes: issue #56.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ constructor please.
 
 Currently entity classes are only supported through the use of `->setStyle()`.
 
+To skip properties that not exist in database you can use `@Relational\isNotColumn` annotation.
+
 ### Updating
 
 You've fetched something, changed it and you need to save it back. Easy:

--- a/package.ini
+++ b/package.ini
@@ -27,6 +27,7 @@ contributors[] = "Henrique Moody <henriquemoody@gmail.com>"
 contributors[] = "Kinn Coelho Julião <kinncj@gmail.com>"
 contributors[] = "Rogerio Prado de Jesus <rogeriopradoj@gmail.com>"
 contributors[] = "Thiago Rigo <thiagophx@gmail.com>"
+contributors[] = "Felipe Cwb <felipe.cwb@hotmail.com>"
 
 [require]
 php = "5.3"
@@ -38,4 +39,3 @@ library = "php"
 config = "cfg"
 bin = "script"
 public = "www"
-


### PR DESCRIPTION
Create the tests for using privates properties.
Add `Mapper::inferGet()` & `Mapper::getAllProperties()`.
Add use of annotation `@Relational\isNotColumn` to non column of database.
Removed some unused variables.
