### PR TITLE
Fixed typo in Mapper::extractAndOperateMixins

### DIFF
--- a/library/Respect/Relational/Mapper.php
+++ b/library/Respect/Relational/Mapper.php
@@ -141,7 +141,7 @@ class Mapper extends AbstractMapper implements
             } else {
                 $mixCols['id'] = null;
                 $cols = array_diff($cols, $mixCols); //Remove mixin columns
-                $this->rawinsert($mixCols, $this->__get($mix));
+                $this->rawInsert($mixCols, $this->__get($mix));
             }
         }
 


### PR DESCRIPTION
Typo located at line ``Respect\Relational\Mapper:144``.